### PR TITLE
python2, python3 모두 호환되는 inspect 모듈을 사용하도록 수정

### DIFF
--- a/tutil/functional.py
+++ b/tutil/functional.py
@@ -2,15 +2,12 @@
 
 import sys
 import functools
+import inspect
 
-py_version = sys.version[0]
 if sys.version[0:3] == '2.7':
     from collections import Iterable
-    import funcsigs
-    inspect = funcsigs
 else:
     from collections.abc import Iterable
-    import inspect
 
 def is_number(v):
     try:
@@ -24,7 +21,7 @@ def iterable(obj):
     return isinstance(obj, Iterable)
 
 def curry(f):
-    args_cnt = len(inspect.signature(f).parameters)
+    args_cnt = len(inspect.getargspec(f).args)
     default_args_cnt = len(f.__defaults__) if f.__defaults__ else 0
 
     def curried(first, *args):


### PR DESCRIPTION
* Fix #1
* python2, 3 모두 호환되는 inspect.getargspec(..) 함수를 사용하도록 수정
* 불필요한 import 모듈(funcsigs) 제거